### PR TITLE
Add S3 storage endpoints for converted weights

### DIFF
--- a/dpn.py
+++ b/dpn.py
@@ -25,13 +25,13 @@ __all__ = ['DPN', 'dpn68', 'dpn68b', 'dpn92', 'dpn98', 'dpn131', 'dpn107']
 
 # If anyone able to provide direct link hosting, more than happy to fill these out.. -rwightman
 model_urls = {
-    'dpn68': '',
-    'dpn68b-extra': '',
+    'dpn68': 'https://s3.amazonaws.com/dpn-pytorch-weights/dpn68.pth',
+    'dpn68b-extra': 'https://s3.amazonaws.com/dpn-pytorch-weights/dpn68b-extra.pth',
     'dpn92': '',
-    'dpn92-extra': '',
-    'dpn98': '',
-    'dpn131': '',
-    'dpn107-extra': ''
+    'dpn92-extra': 'https://s3.amazonaws.com/dpn-pytorch-weights/dpn92-extra.pth',
+    'dpn98': 'https://s3.amazonaws.com/dpn-pytorch-weights/dpn98.pth',
+    'dpn131': 'https://s3.amazonaws.com/dpn-pytorch-weights/dpn131.pth',
+    'dpn107-extra': 'https://s3.amazonaws.com/dpn-pytorch-weights/dpn107-extra.pth'
 }
 
 

--- a/dpn.py
+++ b/dpn.py
@@ -25,13 +25,22 @@ __all__ = ['DPN', 'dpn68', 'dpn68b', 'dpn92', 'dpn98', 'dpn131', 'dpn107']
 
 # If anyone able to provide direct link hosting, more than happy to fill these out.. -rwightman
 model_urls = {
-    'dpn68': 'https://s3.amazonaws.com/dpn-pytorch-weights/dpn68.pth',
-    'dpn68b-extra': 'https://s3.amazonaws.com/dpn-pytorch-weights/dpn68b-extra.pth',
+    'dpn68':
+        'https://s3.amazonaws.com/dpn-pytorch-weights/dpn68-66bebafa7.pth',
+    'dpn68b-extra':
+        'https://s3.amazonaws.com/dpn-pytorch-weights/'
+        'dpn68b_extra-84854c156.pth',
     'dpn92': '',
-    'dpn92-extra': 'https://s3.amazonaws.com/dpn-pytorch-weights/dpn92-extra.pth',
-    'dpn98': 'https://s3.amazonaws.com/dpn-pytorch-weights/dpn98.pth',
-    'dpn131': 'https://s3.amazonaws.com/dpn-pytorch-weights/dpn131.pth',
-    'dpn107-extra': 'https://s3.amazonaws.com/dpn-pytorch-weights/dpn107-extra.pth'
+    'dpn92-extra':
+        'https://s3.amazonaws.com/dpn-pytorch-weights/'
+        'dpn92_extra-b040e4a9b.pth',
+    'dpn98':
+        'https://s3.amazonaws.com/dpn-pytorch-weights/dpn98-5b90dec4d.pth',
+    'dpn131':
+        'https://s3.amazonaws.com/dpn-pytorch-weights/dpn131-71dfe43e0.pth',
+    'dpn107-extra':
+        'https://s3.amazonaws.com/dpn-pytorch-weights/'
+        'dpn107_extra-1ac7121e2.pth'
 }
 
 


### PR DESCRIPTION
I uploaded some of the PyTorch converted weights to my S3 account, I hope that the traffic does not account to 20000 downloads per month!